### PR TITLE
Fixing commonjs import issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littleprompt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A tiny, chainable TypeScript/Node.js library for building effective and structured prompts.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc --project tsconfig.cjs.json && copy dist\\index.js dist\\index.cjs",
     "test": "jest",
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit"

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/index.ts"]
+}


### PR DESCRIPTION
When I deployed 0.1.0, I included a require export that pointed to a non-existent file. 